### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,45 +6,45 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AK9750 KEYWORD1
+AK9750	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin			KEYWORD2
-getIR1 			KEYWORD2
-getIR2 			KEYWORD2
-getIR3 			KEYWORD2
-getIR4 			KEYWORD2
-refresh			KEYWORD2
-available		KEYWORD2
-overrun			KEYWORD2
+begin	KEYWORD2
+getIR1	KEYWORD2
+getIR2	KEYWORD2
+getIR3	KEYWORD2
+getIR4	KEYWORD2
+refresh	KEYWORD2
+available	KEYWORD2
+overrun	KEYWORD2
 
-setMode			KEYWORD2
-setCutoffFrequency KEYWORD2
+setMode	KEYWORD2
+setCutoffFrequency	KEYWORD2
 
-getTemperature 	KEYWORD2
-getTemperatureF 	KEYWORD2
+getTemperature	KEYWORD2
+getTemperatureF	KEYWORD2
 
-softReset		KEYWORD2
+softReset	KEYWORD2
 
 setThresholdIr2Ir4	KEYWORD2
 setHysteresisIr2Ir4	KEYWORD2
 setThresholdIr1Ir3	KEYWORD2
 setHysteresisIr1Ir3	KEYWORD2
-readHysteresis		KEYWORD2
-readThreshold		KEYWORD2
+readHysteresis	KEYWORD2
+readThreshold	KEYWORD2
 
 setThresholdEepromIr2Ir4	KEYWORD2
 setHysteresisEepromIr2Ir4	KEYWORD2
 setThresholdEepromIr1Ir3	KEYWORD2
 setHysteresisEepromIr1Ir3	KEYWORD2
-readHysteresisEeprom		KEYWORD2
-readThresholdEeprom			KEYWORD2
+readHysteresisEeprom	KEYWORD2
+readThresholdEeprom	KEYWORD2
 
-enableDebugging KEYWORD2
-disableDebugging KEYWORD2
+enableDebugging	KEYWORD2
+disableDebugging	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords